### PR TITLE
Catch possible exceptions in list blobs operation.

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/azure/storage/BlobsRetriever.java
+++ b/src/main/java/org/wso2/carbon/connector/azure/storage/BlobsRetriever.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.connector.azure.storage.util.ResultPayloadCreator;
 
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
+import java.util.NoSuchElementException;
 
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.StorageException;
@@ -77,6 +78,9 @@ public class BlobsRetriever extends AbstractConnector {
             handleException("Invalid account key found.", e, messageContext);
         } catch (StorageException e) {
             handleException("Error occurred while connecting to the storage.", e, messageContext);
+        }catch (NoSuchElementException e){
+            // No such element exception can be occurred due to server authentication failure.
+            handleException("Error occurred while listing the container", e, messageContext);
         }
         messageContext.getEnvelope().getBody().addChild(result);
     }


### PR DESCRIPTION
## Purpose
It is possible throwing the NoSuchElementException while executing the container.listBlobs() in [1]. Implementing a proper catch block with an error message. 

[1] https://github.com/wso2-extensions/esb-connector-msazurestorage/blob/9436760f729430433f266292dde5af9420aca196/src/main/java/org/wso2/carbon/connector/azure/storage/BlobsRetriever.java#L66



